### PR TITLE
Temporary fix for the Default Value map widget error

### DIFF
--- a/cnddb_prj/media/js/views/components/widgets/map.js
+++ b/cnddb_prj/media/js/views/components/widgets/map.js
@@ -1797,7 +1797,7 @@ define([
                 self.map.on('moveend', self.updateConfigs);
             }
 
-            if (self.defaultValueType() && self.defaultValueType() != '' || self.defaultValueType() > 0) {
+            if (self.defaultValueType() && self.defaultValueType() > 10) {
                 if (self.defaultValueType() == 1){
                     self.value(self.defaultValue());
                 }
@@ -1934,7 +1934,7 @@ define([
                     });
                 }
             };
-            this.defaultValueType.subscribe(this.loadDefaultValue);
+            // this.defaultValueType.subscribe(this.loadDefaultValue);
         }
 
         this.mapStyle.layers = this.addInitialLayers();


### PR DESCRIPTION
Disables the 'defaultValue' for the map widget because it was causing an error.